### PR TITLE
Potential fix for code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -1260,11 +1260,11 @@ func parseTheme(defaultTheme *tui.ColorTheme, str string) (*tui.ColorTheme, erro
 						if rrggbb.MatchString(component) {
 							cattr.Color = tui.HexToColor(component)
 						} else {
-							ansi32, err := strconv.Atoi(component)
+							ansi32, err := strconv.ParseInt(component, 10, 32)
 							if err != nil || ansi32 < -1 || ansi32 > 255 {
 								fail()
 							}
-							cattr.Color = tui.Color(ansi32)
+							cattr.Color = tui.Color(int32(ansi32))
 						}
 					}
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/khulnasoft/tug/security/code-scanning/4](https://github.com/khulnasoft/tug/security/code-scanning/4)

To fix the problem, we should ensure that the parsed integer value fits within the range of the `tui.Color` type. We can achieve this by using `strconv.ParseInt` with a specified bit size that matches the `tui.Color` type. This way, we avoid any potential issues with architecture-dependent bit sizes.

- Replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying a bit size of 32.
- Ensure that the parsed value is within the valid range for `tui.Color`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
